### PR TITLE
Fix #15: Run tests only on pull requests, not on push events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Build & Test
 
 on:
-  push:
-    branches: [master, develop]
   pull_request:
     branches: [master, develop]
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Description
This PR fixes issue #15 by modifying the GitHub workflow configuration to only execute tests on pull request events, not on push events.

## Changes Made
- Removed the `push` trigger from the workflow configuration
- Retained the `pull_request` trigger with its existing configuration

## Related Issues
Closes #15

## Testing
The workflow will now only trigger when PRs are opened, synchronized, or reopened against the master or develop branches.